### PR TITLE
[RFC] Add authtoken auth using django_rest framework

### DIFF
--- a/nodeshot/conf/settings.py
+++ b/nodeshot/conf/settings.py
@@ -134,6 +134,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_gis',
     'rest_framework_swagger',
+    'rest_framework.authtoken',
     'netfields',
     'leaflet',
     'smuggler',


### PR DESCRIPTION
Here a one-line patch from @cvalenti that allow the users to use query api using auth token.

To generate a token (coder way):
```
from rest_framework.authtoken.models import Token
from django.contrib.auth import get_user_model
User = get_user_model()
user = User.objects.get(username='admin')
token = Token.objects.create(user=user_admin)
print token.key
```

to use it:
```
curl -X GET <url> -H 'Authorization: Token <token_id>' | python -m json.tool
```

INVESTIGATION NEEDED: @cvalenti, @nemesisdesign  How to generate auth token from admin interface?
Q: Where this should be documented?