### PR TITLE
change colorset for elevation graph to steelblue default theme

### DIFF
--- a/nodeshot/ui/default/static/ui/nodeshot/js/views/map.js
+++ b/nodeshot/ui/default/static/ui/nodeshot/js/views/map.js
@@ -996,6 +996,7 @@
                 // create control
                 var el = L.control.elevation({
                         position: 'bottomright',
+                        theme: "steelblue-theme",
                         width: 1020,
                         height: 299,
                         margins: {


### PR DESCRIPTION
Change color theme for leaflet elevation graph to **steelblue**, a default provided theme that look like this

![screen shot 2017-02-13 at 20 44 13](https://cloud.githubusercontent.com/assets/4076473/22924951/622b06f8-f2a7-11e6-98e7-c421f11e5379.png)

the result provides better contrast for the elevation graph and the icons
![screen shot 2017-02-14 at 11 20 22](https://cloud.githubusercontent.com/assets/4076473/22925073/b2428a80-f2a7-11e6-85a1-07f472267f9f.png)

The screenshots are taken from ninux.nodeshot.org by changing the class from **lime-theme** to **steelblue-theme**.

I couldn't see the map in the development installation of nodeshot but I could see that the theme was indeed changed

Close #270.